### PR TITLE
ci(merge-schedule): used a personal access token for the bot instead of the default token

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: gr2m/merge-schedule-action@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
so that the merge can still trigger other actions, like twitter-together